### PR TITLE
Additional harvest fields

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -471,6 +471,9 @@ type BeefyCLVaultHarvestEvent @entity(immutable: true) {
   underlyingBalance0: BigDecimal!
   "The vault's balance of token1 at time of harvest"
   underlyingBalance1: BigDecimal!
+
+  "The price of token0 in token1 at time of harvest"
+  priceOfToken0InToken1: BigDecimal!
 }
 
 #######################

--- a/src/harvest.ts
+++ b/src/harvest.ts
@@ -114,6 +114,7 @@ export function handleStrategyHarvest(event: HarvestEvent): void {
   harvest.harvestValueUSD = harvest.harvestedAmount0USD.plus(harvest.harvestedAmount1USD)
   harvest.underlyingBalance0 = vaultBalanceUnderlying0
   harvest.underlyingBalance1 = vaultBalanceUnderlying1
+  harvest.priceOfToken0InToken1 = currentPriceInToken1
   harvest.save()
 
   vault.currentPriceOfToken0InToken1 = currentPriceInToken1


### PR DESCRIPTION
Add the following fields to harvest events:
- underlyingBalance0
- underlyingBalance1
- priceOfToken1InToken0

These 3 fields allow us to fetch as accurate apy numbers as we can hope for