### PR TITLE
Add total underlying amounts to fee events

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -757,6 +757,10 @@ type ClmManagerCollectionEvent @entity(immutable: true) {
   underlyingAltAmount0: BigInt!
   "Amount of underlying tokens in the CLM assigned to the alt position in the second token."
   underlyingAltAmount1: BigInt!
+  "Total Amount of underlying token0 in the CLM (includes idle funds)"
+  totalUnderlyingAmount0: BigInt!
+  "Total Amount of underlying token1 in the CLM (includes idle funds)"
+  totalUnderlyingAmount1: BigInt!
 
   "Amount of collected fees in the first token"
   collectedAmount0: BigInt!

--- a/src/clm/compound.ts
+++ b/src/clm/compound.ts
@@ -135,6 +135,8 @@ function handleClmStrategyFees(
   collect.underlyingMainAmount1 = clmData.token1PositionMainBalance
   collect.underlyingAltAmount0 = clmData.token0PositionAltBalance
   collect.underlyingAltAmount1 = clmData.token1PositionAltBalance
+  collect.totalUnderlyingAmount0 = clmData.totalUnderlyingAmount0
+  collect.totalUnderlyingAmount1 = clmData.totalUnderlyingAmount1
   collect.collectedAmount0 = collectedAmount0
   collect.collectedAmount1 = collectedAmount1
   collect.collectedOutputAmounts = collectedOutputAmounts


### PR DESCRIPTION
Add total underlying amounts to fee events for use when calculating clm aprs. Currently apr is being computed from main/alt position alone when the entire clm tokens (even those sitting idle) should be taken into account